### PR TITLE
Fix loading of test fixture project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.swift]
+indent_size = 4
+indent_style = space
+charset = utf-8
+trim_trailing_whitespace = false

--- a/SourceKittenDaemon/Completer.swift
+++ b/SourceKittenDaemon/Completer.swift
@@ -39,14 +39,17 @@ internal enum ProjectType {
             return s
         }
     }
-    
-    func pbxProject() -> String? {
-        let fileManager = NSFileManager.defaultManager()
-        let pbxFile = (self.path() as NSString).stringByAppendingPathComponent("project.pbxproj")
-        if !fileManager.fileExistsAtPath(pbxFile) { return nil }
-        
-        return pbxFile
+
+    func xcodeprojURL() -> NSURL? {
+        switch self {
+        case .Project: return NSURL(fileURLWithPath: path(), isDirectory: true)
+        // @TODO : implement folder and workspace support. This involves looking for
+        // nested .xcodeproj's but workspaces will have to somehow support multiple .xcodeproj's
+        case .Folder: fatalError("Folder projects not supported yet")
+        case .Workspace: fatalError("Workspace projects not supported yet")
+        }
     }
+    
 }
 
 internal enum CompletionResult {

--- a/SourceKittenDaemon/ServerCommand.swift
+++ b/SourceKittenDaemon/ServerCommand.swift
@@ -39,12 +39,7 @@ struct ServerStartCommand: CommandType {
                 return .Failure(.CommandError(.InvalidArgument(description: "Need either project, workspace, or folder")))
             }
             
-            guard let pbxProject = project.pbxProject()
-                else {
-                return .Failure(.CommandError(.InvalidArgument(description: "Could not find pbx project in \(project.path())")))
-            }
-            
-            guard let parser = XcodeParser(path: pbxProject,
+            guard let parser = XcodeParser(project: project,
                 targetName: options.target.isEmpty ? nil : options.target)
                 else {
                 return .Failure(.CommandError(.InvalidArgument(description: "Could not create project parser for \(project.path())")))

--- a/SourceKittenDaemon/XcodeParser.swift
+++ b/SourceKittenDaemon/XcodeParser.swift
@@ -22,8 +22,6 @@ struct ProjectObject {
 
 struct XcodeParser {
     
-    let path: String
-    
     let proj: XCProjectFile
     
     var frameworks: [ProjectObject]
@@ -32,23 +30,19 @@ struct XcodeParser {
     
     let target: PBXNativeTarget
     
-    init?(path: String, targetName: String?) {
+    init?(project: ProjectType, targetName: String?) {
         
-        let xcodeproj = NSURL(fileURLWithPath: path)
-        print(xcodeproj.path)
-
         let aProject: XCProjectFile
         do {
-            aProject = try XCProjectFile(xcodeprojURL: xcodeproj)
+            aProject = try XCProjectFile(xcodeprojURL: project.xcodeprojURL()!)
         } catch (let err as ProjectFileError) {
             print(err.description)
             return nil
         } catch (_ as NSError) {
-            print("Could not read xcode project: \(path)")
+            print("Could not read xcode project: \(project.path())")
             return nil
         }
         
-        self.path = path
         self.proj = aProject
         self.frameworks = []
         self.projectFiles = []

--- a/SourceKittenDaemon/XcodeParser.swift
+++ b/SourceKittenDaemon/XcodeParser.swift
@@ -35,10 +35,17 @@ struct XcodeParser {
     init?(path: String, targetName: String?) {
         
         let xcodeproj = NSURL(fileURLWithPath: path)
-        guard let aProject = try? XCProjectFile(xcodeprojURL: xcodeproj)
-            else {
-                print("Could not read xcode project: \(path)")
-                return nil
+        print(xcodeproj.path)
+
+        let aProject: XCProjectFile
+        do {
+            aProject = try XCProjectFile(xcodeprojURL: xcodeproj)
+        } catch (let err as ProjectFileError) {
+            print(err.description)
+            return nil
+        } catch (_ as NSError) {
+            print("Could not read xcode project: \(path)")
+            return nil
         }
         
         self.path = path


### PR DESCRIPTION
Not sure if this is heading in the right direction but the test fixture
can now be read after this patch:

* `ProjectType` can give a `xcodeproj` url instead of `pbxproject`
* `XCodeParser` takes a `ProjectType` now instead of a `String` (path)
* `folder` and `workspace` options throw fatal errors for now (seems
  like `XCProjectFile` only supports one `xcodeproj`, whereas folder and
  workspace options imply multiple projects)

> Let ProjectType handle the xcodeproj instead
> 
> It seems like XCProjectFile expects a xcodeproj url. Before this patch a
> pbxproject was being passed instead which cause XCProjectFile to fail
> initialization.
> 
> Retrieving this is simple when a project is given to the daemon. I've
> deprecated usage for workspace and folder options for now because I don't
> see an easy way to handle them.