### PR TITLE
Remove problematic entry from @rpath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ $(DIST): $(BUILD)
 	cp "$(BUILD)$(APPLICATION_FOLDER)/Contents/MacOS/SourceKittenDaemon" "$(DIST)$(BINARIES_FOLDER)/sourcekittendaemon"
 	cp -r "$(BUILD)$(APPLICATION_FOLDER)/Contents/Frameworks/" "$(DIST)$(FRAMEWORKS_FOLDER)/"
 	install_name_tool -add_rpath "@executable_path/..$(FRAMEWORKS_FOLDER)" "$(DIST)$(BINARIES_FOLDER)/sourcekittendaemon"
+	install_name_tool -delete_rpath "@executable_path/../Frameworks" "$(DIST)$(BINARIES_FOLDER)/sourcekittendaemon"
 
 SourceKittenDaemon.pkg: $(DIST)
 	pkgbuild \


### PR DESCRIPTION
Removes `@executable_path/../Framework` from `@rpath` when building for
distribution.

In unique situations where a user has both `sourcekitten` and
`sourcekittendaemon` installed, `sourcekittendaemon` will find
frameworks in `/usr/local/Frameworks` rather than
`/usr/local/lib/SourcekittenDaemon.frameworks`. If the framework found
is incompatible with the desired one, then `sourcekittendaemon` will crash.