### PR TITLE
Check whether the commit can be built on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: objective-c
+osx_image: xcode7.3
+xcode_project: SourceKittenDaemon.xcodeproj
+xcode_scheme:
+  - SourceKittenDaemon
+xcode_sdk:
+  - macosx10.11
+git:
+  submodules: false
+before_install:
+  - git submodule update --init --recursive
+  - carthage build --platform Mac
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ xcode_sdk:
 git:
   submodules: false
 before_install:
-  - git submodule update --init --recursive
-  - carthage build --platform Mac
+  - make
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ xcode_sdk:
   - macosx10.11
 git:
   submodules: false
-before_install:
+install:
   - make
 notifications:
   email: false

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,8 @@
 # SourceKittenDaemon
 ## Swift Auto Completion Helper
 
+[![Travis][badge-travis]][travis]
+
 This is a simple daemon that can read Xcode Swift projects and offers auto completion for Swift files and more over a built-in webserver.
 Effectively, this allows any kind of editor like Vim, Emacs, Sublime, or Atom to support Swift, Auto Completion, and Xcode projects.
 
@@ -86,3 +88,6 @@ SourceKittenDaemon is not Linux-Ready yet, but I'll investigate this in the next
 ## Thanks
 - A *lot* of thanks go to [Nathan Kot](https://github.com/nathankot) who wrote most parts of this.
 - [Tomoya Kose](https://github.com/mitsuse) for updating the project so it works with Homebrew again
+
+[badge-travis]: https://img.shields.io/travis/terhechte/SourceKittenDaemon.svg?style=flat-square
+[travis]: https://travis-ci.org/terhechte/SourceKittenDaemon/builds


### PR DESCRIPTION
I tried building SourceKittenDaemon on Travis CI. It may be useful to guarantee build passes with clean environment and to automate deployment in future. Please check the build status (This is a temporary link):

> https://travis-ci.org/mitsuse/SourceKittenDaemon/builds

NOTE: This pull-request cannot be built until #33 is fixed.