### PR TITLE
Tolerate multiple and preceding/trailing spaces in project settings

### DIFF
--- a/SourceKittenDaemon/Project/Project.swift
+++ b/SourceKittenDaemon/Project/Project.swift
@@ -68,17 +68,17 @@ class Project {
 
     var frameworkSearchPaths: [String] {
         guard let s = xcodebuildSettings["FRAMEWORK_SEARCH_PATHS"] else { return [] }
-        return s.componentsSeparatedByString(" ")
+        return s.componentsSeparatedByString(" ").filter{return !$0.isEmpty}
     }
 
     var customSwiftCompilerFlags: [String] {
         guard let s = xcodebuildSettings["OTHER_SWIFT_FLAGS"] else { return [] }
-        return s.componentsSeparatedByString(" ")
+        return s.componentsSeparatedByString(" ").filter{return !$0.isEmpty}
     }
 
     var gccPreprocessorDefinitions: [String] {
         guard let s = xcodebuildSettings["GCC_PREPROCESSOR_DEFINITIONS"] else { return [] }
-        return s.componentsSeparatedByString(" ")
+        return s.componentsSeparatedByString(" ").filter{return !$0.isEmpty}
     }
 
     var sourceObjects: [ProjectObject] {


### PR DESCRIPTION
I was tripped up by the GCC_PREPROCESSOR_DEFINITIONS one. In my project, this setting is "$(inherited) COCOAPODS=1", and $(inherited) is empty, so the result is that xcodebuild --showSettings lists it as " COCOAPODS=1", and it gets parsed as two preprocessor definitions with the first being empty. This confuses sourcekitten and the result is that I get no completions. The change allows extra spaces in these parameters.