### PR TITLE
Copy dynamic libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,12 @@ clean:
 	rm -rf "$(BUILD)"
 
 .PHONY: install
-install: $(DIST)$(BINARIES_FOLDER)/sourcekittendaemon
+install: $(DIST)$(BINARIES_FOLDER)/sourcekittendaemon $(DIST)$(LIB_FOLDER)/libCYaml.dylib $(DIST)$(LIB_FOLDER)/libCLibreSSL.dylib
 	mkdir -p "$(PREFIX)$(BINARIES_FOLDER)"
+	mkdir -p "$(PREFIX)$(LIB_FOLDER)"
 	cp -f "$(DIST)$(BINARIES_FOLDER)/sourcekittendaemon" "$(PREFIX)$(BINARIES_FOLDER)/"
+	cp -f "$(DIST)$(LIB_FOLDER)/libCYaml.dylib" "$(PREFIX)$(LIB_FOLDER)/"
+	cp -f "$(DIST)$(LIB_FOLDER)/libCLibreSSL.dylib" "$(PREFIX)$(LIB_FOLDER)/"
 
 .PHONY: test
 test:


### PR DESCRIPTION
I cloned this repository and run `make install` to install sourcekittendaemon. However, after that, the following error occured when I tried to run sourcekittendaemon.

``` shell
$ sourcekittendaemon help
dyld: Library not loaded: /usr/local/lib/libCYaml.dylib
  Referenced from: /usr/local/bin/sourcekittendaemon
  Reason: image not found
[1]    96863 abort      sourcekittendaemon help
```

This error seems like be similar with the problem which is reported in following issue.

> [Release 0.1.6 from SourceKittenDaemon.pkg is incorrectly linked · Issue #60 · terhechte/SourceKittenDaemon](https://github.com/terhechte/SourceKittenDaemon/issues/60)

When I used the makefile which is attached to [this comment](https://github.com/terhechte/SourceKittenDaemon/issues/60#issuecomment-298191547), no errors occurred.

Dynamic library references has been fixed already and merged. But it seems like to lacked processes for copying libraries. So, in my environment, there are no dynamic libraries (libCYaml and libCLibreSSL) at `/usr/local/lib` after install, and failed to run sourcekittendaemon.

I fixed this.