### PR TITLE
Swift 5 Support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -38,6 +38,15 @@
         }
       },
       {
+        "package": "Result",
+        "repositoryURL": "https://github.com/antitypical/Result.git",
+        "state": {
+          "branch": "master",
+          "revision": "908184a92205a252f409bd0341ab645ae83a8bc3",
+          "version": null
+        }
+      },
+      {
         "package": "SourceKitten",
         "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,18 +5,18 @@
         "package": "Commandant",
         "repositoryURL": "https://github.com/Carthage/Commandant.git",
         "state": {
-          "branch": null,
-          "revision": "07cad52573bad19d95844035bf0b25acddf6b0f6",
-          "version": "0.15.0"
+          "branch": "master",
+          "revision": "ab68611013dec67413628ac87c1f29e8427bc8e4",
+          "version": null
         }
       },
       {
         "package": "Embassy",
-        "repositoryURL": "https://github.com/envoy/Embassy.git",
+        "repositoryURL": "https://github.com/michaelnew/Embassy.git",
         "state": {
-          "branch": null,
-          "revision": "43d52f80e79b84eaa7e238d942be59e86db156a6",
-          "version": "4.0.8"
+          "branch": "master",
+          "revision": "410ca9bc0312397941bb513d65f4ca5f82451a2e",
+          "version": null
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "cd6dfb86f496fcd96ce0bc6da962cd936bf41903",
-          "version": "7.3.1"
+          "revision": "43304bf2b1579fd555f2fdd51742771c1e4f2b98",
+          "version": "8.0.1"
         }
       },
       {
@@ -33,26 +33,17 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "5fbf13871d185526993130c3a1fad0b70bfe37ce",
-          "version": "1.3.2"
-        }
-      },
-      {
-        "package": "Result",
-        "repositoryURL": "https://github.com/antitypical/Result.git",
-        "state": {
-          "branch": null,
-          "revision": "8fc088dcf72802801efeecba76ea8fb041fb773d",
-          "version": "4.0.0"
+          "revision": "0b4ed6c706dd0cce923b5019a605a9bcc6b1b600",
+          "version": "2.0.0"
         }
       },
       {
         "package": "SourceKitten",
         "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
         "state": {
-          "branch": null,
-          "revision": "4be914be6fa49cd30b1e7ef5d32d06c037d8f469",
-          "version": "0.21.2"
+          "branch": "master",
+          "revision": "47574a0b13576d909ad827365a09f96dca14a0f3",
+          "version": null
         }
       },
       {
@@ -60,17 +51,17 @@
         "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
         "state": {
           "branch": null,
-          "revision": "0ce63a93a455adb3cd5e4c55f78f1232a590a5a5",
-          "version": "4.7.2"
+          "revision": "0d6bb315528888edde0dafe93564f074669c44e9",
+          "version": "4.8.0"
         }
       },
       {
         "package": "XcodeEdit",
-        "repositoryURL": "https://github.com/felix91gr/XcodeEdit.git",
+        "repositoryURL": "https://github.com/tomlokhorst/XcodeEdit",
         "state": {
-          "branch": null,
-          "revision": "cf8e15a35ec5bfa350bf3bb96ebebe733123c4f2",
-          "version": "1.1.3"
+          "branch": "develop",
+          "revision": "6cf2916aac748b9a687c2bfd1ef27d2adb70453b",
+          "version": null
         }
       },
       {
@@ -78,8 +69,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "26ab35f50ea891e8edefcc9d975db2f6b67e1d68",
-          "version": "1.0.1"
+          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
+          "version": "2.0.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,11 +11,29 @@
         }
       },
       {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "7cd2f8cacc4d22f21bc0b2309c3b18acf7957b66",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "c228db5d2ad1b01ebc84435e823e6cca4e3db98b",
+          "version": "1.2.0"
+        }
+      },
+      {
         "package": "Embassy",
-        "repositoryURL": "https://github.com/michaelnew/Embassy.git",
+        "repositoryURL": "https://github.com/envoy/Embassy.git",
         "state": {
           "branch": "master",
-          "revision": "410ca9bc0312397941bb513d65f4ca5f82451a2e",
+          "revision": "189436100c00efbf5fb2653fe7972a9371db0a91",
           "version": null
         }
       },
@@ -24,8 +42,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "43304bf2b1579fd555f2fdd51742771c1e4f2b98",
-          "version": "8.0.1"
+          "revision": "b02b00b30b6353632aa4a5fb6124f8147f7140c0",
+          "version": "8.0.5"
         }
       },
       {
@@ -33,8 +51,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "0b4ed6c706dd0cce923b5019a605a9bcc6b1b600",
-          "version": "2.0.0"
+          "revision": "33682c2f6230c60614861dfc61df267e11a1602f",
+          "version": "2.2.0"
         }
       },
       {
@@ -42,7 +60,7 @@
         "repositoryURL": "https://github.com/antitypical/Result.git",
         "state": {
           "branch": "master",
-          "revision": "908184a92205a252f409bd0341ab645ae83a8bc3",
+          "revision": "c30700bfcab7f555bf1d386fdd609407a94f369c",
           "version": null
         }
       },
@@ -51,7 +69,7 @@
         "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
         "state": {
           "branch": "master",
-          "revision": "47574a0b13576d909ad827365a09f96dca14a0f3",
+          "revision": "1c54dce13d05c6f3b442b904e14d9df9393e80ec",
           "version": null
         }
       },
@@ -60,8 +78,8 @@
         "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
         "state": {
           "branch": null,
-          "revision": "0d6bb315528888edde0dafe93564f074669c44e9",
-          "version": "4.8.0"
+          "revision": "a4931e5c3bafbedeb1601d3bb76bbe835c6d475a",
+          "version": "5.0.1"
         }
       },
       {
@@ -69,7 +87,7 @@
         "repositoryURL": "https://github.com/tomlokhorst/XcodeEdit",
         "state": {
           "branch": "develop",
-          "revision": "6cf2916aac748b9a687c2bfd1ef27d2adb70453b",
+          "revision": "70e4f0e3ad5f5de5360ed865e7b7e32a7a042f83",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -9,13 +9,15 @@ var package = Package(
     .package(url: "https://github.com/Carthage/Commandant.git", .branch("master")),
     .package(url: "https://github.com/jpsim/SourceKitten.git", .branch("master")),
     .package(url: "https://github.com/michaelnew/Embassy.git", .branch("master")),
-    .package(url: "https://github.com/tomlokhorst/XcodeEdit", .branch("develop"))
+    .package(url: "https://github.com/tomlokhorst/XcodeEdit", .branch("develop")),
+    .package(url: "https://github.com/antitypical/Result.git", .branch("master"))
+    
   ],
 
   targets: [
     .target(
 	name: "SourceKittenDaemon",
-	dependencies: ["Commandant", "SourceKittenFramework", "XcodeEdit", "Embassy" ]
+	dependencies: ["Commandant", "SourceKittenFramework", "XcodeEdit", "Embassy", "Result" ]
     ),
     .target(
 	name: "sourcekittend", 

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ var package = Package(
   dependencies: [
     .package(url: "https://github.com/Carthage/Commandant.git", .branch("master")),
     .package(url: "https://github.com/jpsim/SourceKitten.git", .branch("master")),
-    .package(url: "https://github.com/michaelnew/Embassy.git", .branch("master")),
+    .package(url: "https://github.com/envoy/Embassy.git", .branch("master")),
     .package(url: "https://github.com/tomlokhorst/XcodeEdit", .branch("develop")),
     .package(url: "https://github.com/antitypical/Result.git", .branch("master"))
     

--- a/Package.swift
+++ b/Package.swift
@@ -1,22 +1,25 @@
+// swift-tools-version:4.2
+
 import PackageDescription
 
 var package = Package(
   name: "SourceKittenDaemon",
 
-  targets: [
-    Target(name: "SourceKittenDaemon"),
-    Target(name: "sourcekittend", dependencies: [.Target(name: "SourceKittenDaemon")])
-  ],
-
   dependencies: [
-    .Package(url: "https://github.com/Carthage/Commandant.git", versions: Version(0, 12, 0)..<Version(0, 15, .max)),
-    .Package(url: "https://github.com/jpsim/SourceKitten.git", majorVersion: 0, minor: 21),
-    .Package(url: "https://github.com/envoy/Embassy.git", majorVersion: 4),
-    .Package(url: "https://github.com/felix91gr/XcodeEdit.git", majorVersion: 1),
+    .package(url: "https://github.com/Carthage/Commandant.git", .branch("master")),
+    .package(url: "https://github.com/jpsim/SourceKitten.git", .branch("master")),
+    .package(url: "https://github.com/michaelnew/Embassy.git", .branch("master")),
+    .package(url: "https://github.com/tomlokhorst/XcodeEdit", .branch("develop"))
   ],
 
-  exclude: [
-    "Tests/SourceKittenDaemonTests/Fixtures/Sources"
+  targets: [
+    .target(
+	name: "SourceKittenDaemon",
+	dependencies: ["Commandant", "SourceKittenFramework", "XcodeEdit", "Embassy" ]
+    ),
+    .target(
+	name: "sourcekittend", 
+	dependencies: ["SourceKittenDaemon"])
   ]
 )
 

--- a/Sources/SourceKittenDaemon/Completer/Completer.swift
+++ b/Sources/SourceKittenDaemon/Completer/Completer.swift
@@ -146,7 +146,7 @@ class Completer {
         let request = Request.codeCompletionRequest(
                           file: path,
                           contents: contents,
-                          offset: Int64(offset),
+                          offset: ByteCount(offset),
                           arguments: compilerArgs)
      
         do {

--- a/Sources/SourceKittenDaemon/Completer/Completer.swift
+++ b/Sources/SourceKittenDaemon/Completer/Completer.swift
@@ -64,7 +64,7 @@ class FileSystemEventsWrapper {
 
             FSEventStreamScheduleWithRunLoop(eventStream,
                                              runLoop.getCFRunLoop(),
-                                             RunLoopMode.defaultRunLoopMode as CFString)
+                                             RunLoop.Mode.default as CFString)
             
             FSEventStreamStart(eventStream)
         }

--- a/Sources/sourcekittend/StartCommand.swift
+++ b/Sources/sourcekittend/StartCommand.swift
@@ -37,7 +37,7 @@ struct StartCommand: CommandProtocol {
             do {
                 let server = try CompletionServer(project: project, port: options.port)
                 try server.start()
-                return .success()
+                return .success(())
             } catch let error {
                 return Result.failure(CommandError.other(error))
             }


### PR DESCRIPTION
Spent a while trying to get things working again with Xcode 10.2 / Swift 5. I've been using this for a few days and it does seem to work, but probably shouldn't be merged yet.

`Package.swift` had to be updated to the new packaging format, which means all the dependencies *also* have to use the new format. In most cases there aren't tagged releases that we can point to that have the updates, so for now all the dependencies are just the latest on git. Embassy is pointed at my fork right now, but I have a PR open with them, so once that's merged that can be changed back to `envoy/embassy`.

The biggest change here is getting things to work with the latest version of XcodeEdit. I didn't spend much time on this: it was more of a "make it work" effort. This could probably do with some testing and/or review.

I don't think there's anything in *this* project that requires Swift 5, but Commandant won't compile without it. So the update effectively drops support for anything prior to Xcode 10.2.

Currently this is a bit messy, but I wanted to get this out there so no one else has to duplicate the effort.